### PR TITLE
Word priority visible in vocabulary list

### DIFF
--- a/qml/pages/LanguageList.qml
+++ b/qml/pages/LanguageList.qml
@@ -181,11 +181,12 @@ Page {
                 }
 
                 height: parent.height * 0.2
-                width: parent.width * simple_interface.getPriorityOfWord(page.word_id) / 100
+                width: parent.width * simple_interface.getPriorityOfWord(id) / 100
 
                 color: Theme.secondaryHighlightColor
+                visible: (simple_interface.getPriorityOfWord(id) > 1)
                 opacity: .5
-            }            
+            }         
 
             Row {
                 width: parent.width - 2*Theme.paddingLarge

--- a/qml/pages/LanguageList.qml
+++ b/qml/pages/LanguageList.qml
@@ -173,6 +173,19 @@ Page {
         delegate: ListItem {
             id: listitem
             width: parent.width
+            
+            Rectangle {
+                anchors {
+                    bottom: parent.bottom
+                    left: parent.left
+                }
+
+                height: parent.height * 0.2
+                width: parent.width * simple_interface.getPriorityOfWord(page.word_id) / 100
+
+                color: Theme.secondaryHighlightColor
+                opacity: .5
+            }            
 
             Row {
                 width: parent.width - 2*Theme.paddingLarge

--- a/qml/pages/List.qml
+++ b/qml/pages/List.qml
@@ -168,6 +168,20 @@ Page {
         delegate: ListItem {
             id: listitem
             width: parent.width
+            
+            Rectangle {
+                anchors {
+                    bottom: parent.bottom
+                    left: parent.left
+                }
+
+                height: parent.height * 0.2
+                width: parent.width * simple_interface.getPriorityOfWord(id) / 100
+
+                color: Theme.secondaryHighlightColor
+                visible: (simple_interface.getPriorityOfWord(id) > 1)
+                opacity: .5
+            }             
 
             Row {
                 width: parent.width - 2*Theme.paddingLarge


### PR DESCRIPTION
Just one more idea.
It would be useful to have the overview of the priority score of each word in the "Show all vocabulary" view.
After this change, the priority should be visible as a bar at the bottom of the row. (It is untested, I got the inspiration and code concept from gPodder).