### PR TITLE
Dialogs and tweaks

### DIFF
--- a/qml/pages/Add.qml
+++ b/qml/pages/Add.qml
@@ -19,11 +19,13 @@ import Sailfish.Silica 1.0
 import harbour.vocabulary.SettingsProxy 1.0
 import harbour.vocabulary.SimpleInterface 1.0
 
-Page {
+Dialog {
     id: page
     allowedOrientations: Orientation.All
 
     property int language_id: -1
+    canAccept: word.text != "" && translation.text != "" && (page.language_id !== -1 || new_language_input.text !== "")
+    onAccepted: functions.save_word()
 
     Component.onCompleted: {
         page.language_id = settings_proxy.addVocabularyLanguage
@@ -54,7 +56,6 @@ Page {
 
             if(simple_interface.addVocabulary(word.text, translation.text, id)) {
                 settings_proxy.addVocabularyLanguage = id
-                pageStack.pop()
             }
             else {
                 panel.show()
@@ -150,6 +151,13 @@ Page {
         id: silicaFlickable
         anchors.fill: parent
 
+        DialogHeader {
+            id: header
+            //% Save new vocabulary
+            title: qsTr("Add vocabulary")
+            acceptText: qsTr("Save vocabulary")
+        }
+
         VerticalScrollDecorator {}
 
         contentHeight: column.height
@@ -170,23 +178,6 @@ Page {
             id: column
             width: page.width
             spacing: Theme.paddingMedium
-
-            PageHeader {
-                title: qsTr("Add vocabulary")
-            }
-
-            Button {
-                anchors {
-                    left: parent.left
-                    right: parent.right
-                    margins: Theme.horizontalPageMargin
-                }
-
-                enabled: word.text.trim() != "" && translation.text.trim() != "" && (page.language_id !== -1 || new_language_input.text !== "")
-                width: parent.width
-                text: qsTr("Save vocabulary")
-                onClicked: functions.save_word()
-            }
 
             ComboBox {
                 id: languageComboBox

--- a/qml/pages/Add.qml
+++ b/qml/pages/Add.qml
@@ -176,7 +176,8 @@ Dialog {
 
         Column {
             id: column
-            width: page.width
+            width: parent.width
+            anchors.top: header.bottom
             spacing: Theme.paddingMedium
 
             ComboBox {
@@ -215,7 +216,7 @@ Dialog {
             TextArea {
                 id: new_language_input
                 visible: languageComboBox.currentIndex === 0
-                width: page.width
+                width: parent.width
                 EnterKey.onClicked: { text = text.replace("\n", ""); word.focus = true }
                 EnterKey.iconSource: "image://theme/icon-m-enter-next"
                 placeholderText: qsTr("Input new language")
@@ -277,6 +278,7 @@ Dialog {
                 id: word
                 width: parent.width
                 height: implicitHeight
+                EnterKey.enabled: text.length > 0
                 EnterKey.onClicked: { text = text.replace("\n", ""); translation.focus = true }
                 EnterKey.iconSource: "image://theme/icon-m-enter-next"
                 placeholderText: qsTr("Input word or phrase here")

--- a/qml/pages/Add.qml
+++ b/qml/pages/Add.qml
@@ -33,6 +33,9 @@ Dialog {
         functions.load_list()
         functions.load_languages()
         functions.filter_list("")
+
+        // set focus to entry field for word as soon as page is constructed
+        word.focus = true
     }
 
     SettingsProxy {

--- a/qml/pages/Edit.qml
+++ b/qml/pages/Edit.qml
@@ -157,6 +157,7 @@ Dialog {
                 id: word
                 width: parent.width
                 height: implicitHeight
+                EnterKey.enabled: text.length > 0
                 EnterKey.onClicked: { text = text.replace("\n", ""); translation.focus = true }
                 EnterKey.iconSource: "image://theme/icon-m-enter-next"
                 placeholderText: qsTr("Input word or phrase here")

--- a/qml/pages/Edit.qml
+++ b/qml/pages/Edit.qml
@@ -81,6 +81,9 @@ Dialog {
         word.text = simple_interface.getWord(page.word_id)
         translation.text = simple_interface.getTranslationOfWord(page.word_id)
         priority.value = simple_interface.getPriorityOfWord(page.word_id)
+
+        // set focus to entry field for word as soon as page is constructed
+        word.focus = true
     }
 
     ListModel {
@@ -157,7 +160,8 @@ Dialog {
                 id: word
                 width: parent.width
                 height: implicitHeight
-                EnterKey.enabled: text.length > 0
+                cursorPosition: text.length
+                EnterKey.enabled: text.lenght > 0
                 EnterKey.onClicked: { text = text.replace("\n", ""); translation.focus = true }
                 EnterKey.iconSource: "image://theme/icon-m-enter-next"
                 placeholderText: qsTr("Input word or phrase here")

--- a/qml/pages/Edit.qml
+++ b/qml/pages/Edit.qml
@@ -113,7 +113,7 @@ Dialog {
 
         Column {
             id: column
-            width: page.width
+            width: parent.width
             spacing: Theme.paddingMedium
             anchors.top: header.bottom
 

--- a/qml/pages/Edit.qml
+++ b/qml/pages/Edit.qml
@@ -17,12 +17,16 @@
 import QtQuick 2.0
 import Sailfish.Silica 1.0
 
-Page {
+Dialog {
     id: page
     allowedOrientations: Orientation.All
 
     property int word_id: 0
     property int language_id: -1
+
+    canAccept: word.text.trim() != "" && translation.text.trim() != "" && (page.language_id !== -1 || new_language_input.text !== "")
+    onAccepted: functions.save_change()
+
 
     Item {
         id: functions
@@ -43,7 +47,6 @@ Page {
                 var last_page = pageStack.previousPage()
                 last_page.word_changed = true
                 last_page.word_id = page.word_id
-                pageStack.pop()
             }
             else {
                 panel.show()
@@ -96,31 +99,20 @@ Page {
         id: silicaFlickable
         anchors.fill: parent
 
+        DialogHeader {
+            id: header
+            title: qsTr("Edit vocabulary") + " " + simple_interface.getWord(page.word_id)
+            acceptText: qsTr("Save change")
+        }
+
         VerticalScrollDecorator {}
 
-        contentHeight: column.height
 
         Column {
             id: column
             width: page.width
             spacing: Theme.paddingMedium
-
-            PageHeader {
-                title: qsTr("Edit vocabulary") + " " + simple_interface.getWord(page.word_id)
-            }
-
-            Button {
-                anchors {
-                    left: parent.left
-                    right: parent.right
-                    margins: Theme.horizontalPageMargin
-                }
-
-                enabled: word.text.trim() != "" && translation.text.trim() != "" && (page.language_id !== -1 || new_language_input.text !== "")
-                width: parent.width
-                text: qsTr("Save change")
-                onClicked: functions.save_change()
-            }
+            anchors.top: header.bottom
 
             ComboBox {
                 id: languageComboBox


### PR DESCRIPTION
Converts QML pages for adding and editing (`Add.qml`, `Edit.qml`) vocabulary into Silica Dialogs ([no buttons](https://sailfishos.org/develop/docs/silica/sailfish-application-pitfalls.html/#using-buttons-instead-of-platform-style-gestures
), please :wink: ).

Also adds some fine tuning:
- set focus on first entry field (`word`) when adding vocabulary
- enable enter key only after text was input
- move cursor to end of first text field (`word`) when editing
- anchor contents to individual parent instead of page



**New add dialog:**
![Add-Dialog focus-sm](https://user-images.githubusercontent.com/15898292/68977058-3c643600-07ef-11ea-8fea-bdfb8de06d23.jpg)

**Acceptable after input:**
![Add-Dialog-sm](https://user-images.githubusercontent.com/15898292/68977060-3cfccc80-07ef-11ea-8cc8-edf4f2c9a360.jpg)

---
**Edit dialog:**
![Edit-Dialog-sm](https://user-images.githubusercontent.com/15898292/68977061-3d956300-07ef-11ea-963c-0608bc3a58ea.jpg)

