### PR TITLE
Allow to add vocabulary from list view

### DIFF
--- a/qml/pages/Edit.qml
+++ b/qml/pages/Edit.qml
@@ -102,7 +102,7 @@ Page {
 
         Column {
             id: column
-            width: page.width
+            width: parent.width
             spacing: Theme.paddingMedium
 
             PageHeader {

--- a/qml/pages/List.qml
+++ b/qml/pages/List.qml
@@ -220,6 +220,11 @@ Page {
                                    })
                 }
             }
+
+            MenuItem {
+                text: qsTr("Add vocabulary")
+                onClicked: pageStack.push(Qt.resolvedUrl("Add.qml"))
+            }
         }
 
         header: Column {

--- a/qml/pages/List.qml
+++ b/qml/pages/List.qml
@@ -223,7 +223,11 @@ Page {
 
             MenuItem {
                 text: qsTr("Add vocabulary")
-                onClicked: pageStack.push(Qt.resolvedUrl("Add.qml"))
+                onClicked: {
+                    var addDialog = pageStack.push(Qt.resolvedUrl("Add.qml"))
+                    // connect to 'accepted' signal in order to reload vocabulary list after adding new one
+                    addDialog.accepted.connect(function() {functions.load_list()})
+                }
             }
         }
 


### PR DESCRIPTION
Adds a pulley to add new vocabulary from the list of all vocabulary.
Depends on #26 as it connects to the `accepted` signal of the Silica Dialog to reload the list after adding.

![List-menu-entry-sm](https://user-images.githubusercontent.com/15898292/68977852-20fa2a80-07f1-11ea-9769-7692677a6ab8.jpg)
